### PR TITLE
Added doc(cfg attributes. Bumped release to 0.9.3

### DIFF
--- a/abi_stable/Cargo.toml
+++ b/abi_stable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abi_stable"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["rodrimati1992 <rodrimatt1985@gmail.com>"]
 edition="2018"
 license = "MIT/Apache-2.0"
@@ -48,6 +48,8 @@ nonexhaustive_examples=[]
 # https://github.com/rust-lang/rust/pull/80243#event-4161720040
 no_fn_promotion = []
 
+docsrs = []
+
 channels=["crossbeam-channel"]
 
 
@@ -81,3 +83,6 @@ fnv = "1.0.7"
 
 [build-dependencies]
 rustc_version = "0.2.3"
+
+[package.metadata.docs.rs]
+features = ["docsrs", "const_params"]

--- a/abi_stable/src/abi_stability/stable_abi_trait.rs
+++ b/abi_stable/src/abi_stability/stable_abi_trait.rs
@@ -842,12 +842,18 @@ where
 #[cfg(feature = "const_params")]
 macro_rules! impl_stable_abi_array {
     ()=>{
+        /// When the "const_params" feature is disabled,
+        /// this trait is implemented for arrays of up to 32 elements.
+        #[cfg_attr(feature = "docsrs", doc(cfg(feature = "const_params")))]
         unsafe impl<T, const N: usize> GetStaticEquivalent_ for [T; N]
         where T:GetStaticEquivalent_
         {
             type StaticEquivalent=[T::StaticEquivalent; N];
         }
 
+        /// When the "const_params" feature is disabled,
+        /// this trait is implemented for arrays of up to 32 elements.
+        #[cfg_attr(feature = "docsrs", doc(cfg(feature = "const_params")))]
         unsafe impl<T, const N: usize> StableAbi for [T; N]
         where T:StableAbi
         {

--- a/abi_stable/src/external_types.rs
+++ b/abi_stable/src/external_types.rs
@@ -7,17 +7,13 @@ The modules here are named after the crates whose types are being wrapped.
 */
 
 #[cfg(feature="crossbeam-channel")]
+#[cfg_attr(feature = "docsrs", doc(cfg(feature = "channels")))]
 pub mod crossbeam_channel;
-
-#[cfg(not(feature="crossbeam-channel"))]
-/// This is disabled,
-/// enable the "channels" feature to get ffi-safe wrappers for crossbeam channels.
-pub mod crossbeam_channel{}
-
 
 pub mod parking_lot;
 
 #[cfg(feature="serde_json")]
+#[cfg_attr(feature = "docsrs", doc(cfg(feature = "serde_json")))]
 pub mod serde_json;
 
 

--- a/abi_stable/src/lib.rs
+++ b/abi_stable/src/lib.rs
@@ -226,6 +226,8 @@ https://github.com/rodrimati1992/abi_stable_crates/blob/master/readme.md#readme_
     feature(min_const_generics)
 )]
 
+#![cfg_attr(feature = "docsrs", feature(doc_cfg))]
+
 #[allow(unused_imports)]
 #[cfg(test)]
 use abi_stable_shared::file_span;

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,10 @@
 [![Build Status](https://travis-ci.org/rodrimati1992/abi_stable_crates.svg?branch=master)](https://travis-ci.org/rodrimati1992/abi_stable_crates) [![Join the chat at https://gitter.im/abi_stable_crates/community](https://badges.gitter.im/abi_stable_crates/community.svg)](https://gitter.im/abi_stable_crates/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![](https://img.shields.io/crates/v/abi_stable.svg)][crates-io]
+[![api-docs](https://docs.rs/abi_stable/badge.svg)][Documentation]
 
 [crates-io]: https://crates.io/crates/abi_stable
 
-[Documentation.](https://docs.rs/abi_stable)
+[Documentation]: https://docs.rs/abi_stable
 
 For Rust-to-Rust ffi,
 with a focus on creating libraries loaded at program startup,


### PR DESCRIPTION
Added "docsrs" feature, for enabling the `doc(cfg(....))` attributes

The `doc(cfg(....))` attributes document which items require cargo features to ennable.

Fixed documentation badge in readme.