### PR TITLE
0.10.1 release

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,8 +45,8 @@ jobs:
         cd "${{github.workspace}}/testing/1 - loading errors/non_abi_stable_lib/"
         cargo +beta build
 
-        # cd "${{github.workspace}}/testing/version_compatibility/impl_0"
-        # cargo +beta build
+        cd "${{github.workspace}}/testing/version_compatibility/impl_0"
+        cargo +beta build
 
         cd "${{github.workspace}}/"
         rm Cargo.lock
@@ -100,8 +100,8 @@ jobs:
         env "RETURN=error" cargo run
         env "RETURN=panic" cargo run
 
-        # cd "${{github.workspace}}/testing/version_compatibility/user_0"
-        # cargo run
+        cd "${{github.workspace}}/testing/version_compatibility/user_0"
+        cargo run
 
     - uses: actions/checkout@v2
     - name: ci-nighly

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,11 @@ This is the changelog,summarising changes in each version(some minor changes may
 
 # 0.10
 
+### 0.10.1
+
+Fixed support for building in ARM, from this pull request: https://github.com/rodrimati1992/abi_stable_crates/pull/50
+(if this causes other problems with ARM please create an issue!)
+
 ### 0.10.0
 
 Fixed soundness of the code under the Stacked Borrows model, by replacing uses of type-erased `&` and `&mut`s in trait objects and vtables with `RRef` and `RMut`. 

--- a/abi_stable/src/docs/sabi_trait_inherent.rs
+++ b/abi_stable/src/docs/sabi_trait_inherent.rs
@@ -390,9 +390,9 @@ where
 
 [`RObject`]: ../../sabi_trait/struct.RObject.html
 
-[`DynTrait`]: ../struct.DynTrait.html
+[`DynTrait`]: ../../struct.DynTrait.html
 
-[`RBox`]: ../std_types/struct.RObject.html
+[`RBox`]: ../../std_types/struct.RBox.html
 
 [`Action_TO`]: ../../sabi_trait/doc_examples/struct.Action_TO.html
 

--- a/abi_stable/src/erased_types.rs
+++ b/abi_stable/src/erased_types.rs
@@ -41,10 +41,11 @@ pub(crate) mod vtable;
 
 pub(crate) mod traits;
 
+#[doc(no_inline)]
+pub use crate::DynTrait;
 
 pub use self::{
     dyn_trait::{
-        DynTrait,
         DynTraitBound,
         GetVWInterface,
         UneraseError,

--- a/abi_stable/src/erased_types/dyn_trait.rs
+++ b/abi_stable/src/erased_types/dyn_trait.rs
@@ -1120,8 +1120,8 @@ mod priv_ {
         /// 
         /// ```
         /// 
-        /// [`TD_CanDowncast`]: ./type_level/unersability/struct.TD_CanDowncast.html
-        /// [`TD_Opaque`]: ./type_level/unersability/struct.TD_Opaque.html
+        /// [`TD_CanDowncast`]: ./type_level/downcasting/struct.TD_CanDowncast.html
+        /// [`TD_Opaque`]: ./type_level/downcasting/struct.TD_Opaque.html
         pub const fn from_const<T, Downcasting>(
             ptr:&'a T,
             can_it_downcast:Downcasting,

--- a/abi_stable/src/erased_types/traits.rs
+++ b/abi_stable/src/erased_types/traits.rs
@@ -229,7 +229,7 @@ impl InterfaceType for FooInterface {
 /**
 Describes how a type is serialized by [`DynTrait`].
 
-[`DynTrait`]: ./struct.DynTrait.html
+[`DynTrait`]: ../struct.DynTrait.html
 */
 pub trait SerializeImplType<'s> {
     /// An [`InterfaceType`] implementor which determines the 

--- a/abi_stable/src/lib.rs
+++ b/abi_stable/src/lib.rs
@@ -350,7 +350,11 @@ static EXECUTABLE_IDENTITY: AtomicUsize = AtomicUsize::new(1);
 #[doc(inline)]
 pub use crate::{
     abi_stability::StableAbi,
-    erased_types::{DynTrait,ImplType, InterfaceType},
+    erased_types::{
+        dyn_trait::DynTrait,
+        ImplType,
+        InterfaceType,
+    },
 };
 
 #[doc(no_inline)]

--- a/abi_stable/src/proc_macro_reexports/stable_abi_derive.rs
+++ b/abi_stable/src/proc_macro_reexports/stable_abi_derive.rs
@@ -125,7 +125,7 @@ Arguments (what goes inside `#[sabi(kind(Prefix(   <here>   )))]`):
 Declares an ffi-safe pointer to a vtable/module,
 that can be extended in semver compatible versions.<br>
 Uses "<Identifier>" as the name of the prefix struct.<br>
-For more details on prefix-types [look here](../docs/prefix_types/index.html)
+For more details on prefix-types [look here](./docs/prefix_types/index.html)
 
 - `prefix_fields = "<Identifier>")` (optional: defaults to `<DerivingType>_Prefix`):<be>
 Declares a struct with all the field in the deriving type up to(and including)
@@ -137,7 +137,7 @@ named "<Identifier>".
 Declares this enum as being nonexhaustive,
 generating items and impls necessary to wrap this enum in the [`NonExhaustive`] type
 to pass it through ffi.
-For more details on nonexhaustive enums [look here](../docs/sabi_nonexhaustive/index.html)
+For more details on nonexhaustive enums [look here](./docs/sabi_nonexhaustive/index.html)
 
 ###  `#[sabi(module_reflection(...))]`  
 
@@ -501,7 +501,7 @@ pub struct Wrapper<T>{
 ###  On a `#[repr(u8)]` enum.
 
 This enum cannot add variants in minor versions,
-for that you have to use [nonexhaustive enums](../docs/sabi_nonexhaustive/index.html).
+for that you have to use [nonexhaustive enums](./docs/sabi_nonexhaustive/index.html).
 
 ```
 use abi_stable::{
@@ -523,13 +523,13 @@ pub enum Command{
 
 ###  Prefix-types 
 
-For examples of Prefix-types [look here](../docs/prefix_types/index.html#examples).
+For examples of Prefix-types [look here](./docs/prefix_types/index.html#examples).
 
 ###  Nonexhaustive-enums 
 
 For examples of nonexhaustive enums 
 [look here for the first example
-](../docs/sabi_nonexhaustive/index.html#defining-a-deserializable-nonexhaustive-enum).
+](./docs/sabi_nonexhaustive/index.html#defining-a-deserializable-nonexhaustive-enum).
 
 ### Examples of `#[not_stableabi()]`
 

--- a/abi_stable/src/sabi_trait/doc_examples.rs
+++ b/abi_stable/src/sabi_trait/doc_examples.rs
@@ -53,7 +53,7 @@ pub trait DocHiddenTrait{}
 
 
 /// The trait used in examples of `#[sabi_trait]` trait object methods,
-/// [here](../../docs/sabi_trait_inherent/index.html)
+/// in [`abi_stable::docs::sabi_trait_inherent`]
 #[abi_stable::sabi_trait]
 // #[sabi(debug_print_trait)]
 pub trait Action: Debug {

--- a/testing/version_compatibility/impl_0/Cargo.toml
+++ b/testing/version_compatibility/impl_0/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["rodrimati1992 <rodrimatt1985@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-abi_stable={path="../../../abi_stable",package="abi_stable"}
-# abi_stable={version="*"}
+# abi_stable={path="../../../abi_stable",package="abi_stable"}
+abi_stable={version="*"}
 
 [dependencies.version_compatibility_interface]
 version="0.1"


### PR DESCRIPTION
Fixed dead links

Updated changelog

Reenabled version testing in CI

Bringing [the fix](https://github.com/rodrimati1992/abi_stable_crates/pull/50) to make abi_stable *build* on ARM (no idea if there's anything with ARM that makes abi_stable unsound though)