### PR TITLE
Implement `Index` for slices and vectors

### DIFF
--- a/abi_stable/src/std_types/slice_mut.rs
+++ b/abi_stable/src/std_types/slice_mut.rs
@@ -644,8 +644,8 @@ mod test {
 
         assert_eq!(s.index(0), &1);
         assert_eq!(s.index(4), &5);
-        assert_eq!(s.index(..2), &mut [1, 2, 3]);
-        assert_eq!(s.index(1..2), &mut [2, 3]);
+        assert_eq!(s.index(..2), &mut [1, 2]);
+        assert_eq!(s.index(1..2), &mut [2]);
         assert_eq!(s.index(3..), &mut [4, 5]);
     }
 
@@ -656,8 +656,8 @@ mod test {
 
         assert_eq!(s.index_mut(0), &mut 1);
         assert_eq!(s.index_mut(4), &mut 5);
-        assert_eq!(s.index_mut(..2), &mut [1, 2, 3]);
-        assert_eq!(s.index_mut(1..2),&mut [2, 3]);
+        assert_eq!(s.index_mut(..2), &mut [1, 2]);
+        assert_eq!(s.index_mut(1..2),&mut [2]);
         assert_eq!(s.index_mut(3..), &mut [4, 5]);
     }
 }

--- a/abi_stable/src/std_types/slices.rs
+++ b/abi_stable/src/std_types/slices.rs
@@ -531,8 +531,8 @@ mod test {
 
         assert_eq!(s.index(0), &1);
         assert_eq!(s.index(4), &5);
-        assert_eq!(s.index(..2), rslice![1, 2, 3]);
-        assert_eq!(s.index(1..2), rslice![2, 3]);
+        assert_eq!(s.index(..2), rslice![1, 2]);
+        assert_eq!(s.index(1..2), rslice![2]);
         assert_eq!(s.index(3..), rslice![4, 5]);
     }
 }

--- a/abi_stable/src/std_types/vec.rs
+++ b/abi_stable/src/std_types/vec.rs
@@ -1455,8 +1455,8 @@ mod test {
         let s = rvec![1, 2, 3, 4, 5];
         assert_eq!(s.index(0), &1);
         assert_eq!(s.index(4), &5);
-        assert_eq!(s.index(..2), rvec![1, 2, 3]);
-        assert_eq!(s.index(1..2), rvec![2, 3]);
+        assert_eq!(s.index(..2), rvec![1, 2]);
+        assert_eq!(s.index(1..2), rvec![2]);
         assert_eq!(s.index(3..), rvec![4, 5]);
     }
 
@@ -1466,8 +1466,8 @@ mod test {
 
         assert_eq!(s.index_mut(0), &mut 1);
         assert_eq!(s.index_mut(4), &mut 5);
-        assert_eq!(s.index_mut(..2), &mut rvec![1, 2, 3]);
-        assert_eq!(s.index_mut(1..2), &mut rvec![2, 3]);
+        assert_eq!(s.index_mut(..2), &mut rvec![1, 2]);
+        assert_eq!(s.index_mut(1..2), &mut rvec![2]);
         assert_eq!(s.index_mut(3..), &mut rvec![4, 5]);
     }
 
@@ -1476,8 +1476,8 @@ mod test {
         let s = rvec![1, 2, 3, 4, 5];
 
         assert_eq!(s.slice(..), rslice![1, 2, 3, 4, 5]);
-        assert_eq!(s.slice(..2), rslice![1, 2, 3]);
-        assert_eq!(s.slice(1..2), rslice![2, 3]);
+        assert_eq!(s.slice(..2), rslice![1, 2]);
+        assert_eq!(s.slice(1..2), rslice![2]);
         assert_eq!(s.slice(3..), rslice![4, 5]);
     }
 
@@ -1486,8 +1486,8 @@ mod test {
         let mut s = rvec![1, 2, 3, 4, 5];
 
         assert_eq!(s.slice_mut(..), RSliceMut::from_mut_slice(&mut [1, 2, 3, 4, 5]));
-        assert_eq!(s.slice_mut(..2), RSliceMut::from_mut_slice(&mut [1, 2, 3]));
-        assert_eq!(s.slice_mut(1..2), RSliceMut::from_mut_slice(&mut [2, 3]));
+        assert_eq!(s.slice_mut(..2), RSliceMut::from_mut_slice(&mut [1, 2]));
+        assert_eq!(s.slice_mut(1..2), RSliceMut::from_mut_slice(&mut [2]));
         assert_eq!(s.slice_mut(3..), RSliceMut::from_mut_slice(&mut [4, 5]));
     }
 }


### PR DESCRIPTION
`Index` is a trait necessary in any container such as a slice, vector, or similars. It's used by `[T]`, `Vec<T>`, and also external crates such as `tinyvec`. That way, any of these containers can be generalized under this trait.

This PR simply implements `Index` and `IndexMut` wherever needed, and also adds a few tests to make sure they work properly. The implementation is basically the same as `Vec<T>`, taking some ideas from `tinyvec` as well.