### PR TITLE
Support for `f32` and `f64`

### DIFF
--- a/abi_stable/src/abi_stability/stable_abi_trait.rs
+++ b/abi_stable/src/abi_stability/stable_abi_trait.rs
@@ -1092,6 +1092,8 @@ impl_for_primitive_ints!{
     (i32  ,"i32"  ,TLPrimitive::I32),
     (u64  ,"u64"  ,TLPrimitive::U64),
     (i64  ,"i64"  ,TLPrimitive::I64),
+    (f32  ,"f32"  ,TLPrimitive::F32),
+    (f64  ,"f64"  ,TLPrimitive::F64),
     (usize,"usize",TLPrimitive::Usize),
     (isize,"isize",TLPrimitive::Isize),
     (bool ,"bool" ,TLPrimitive::Bool),

--- a/abi_stable/src/type_layout/printing.rs
+++ b/abi_stable/src/type_layout/printing.rs
@@ -269,6 +269,7 @@ impl Debug for FmtFullType {
                 |Some(TLP::U16)|Some(TLP::I16)
                 |Some(TLP::U32)|Some(TLP::I32)
                 |Some(TLP::U64)|Some(TLP::I64)
+                |Some(TLP::F32)|Some(TLP::F64)
                 |Some(TLP::Usize)|Some(TLP::Isize)
                 |Some(TLP::Bool)
                 |None => (self.name, "<", "", ", ", ">"),

--- a/abi_stable/src/type_layout/tl_other.rs
+++ b/abi_stable/src/type_layout/tl_other.rs
@@ -198,6 +198,8 @@ pub enum TLPrimitive{
     I32,
     U64,
     I64,
+    F32,
+    F64,
     Usize,
     Isize,
     Bool,


### PR DESCRIPTION
This PR is all that's needed to close #60. However, the question about the stability of their ABI still remains, so this can't be merged yet. This assumes `f32` and `f64` are supported by the compiler in FFI contexts.

This is written over #59 so that should be merged first anyway.