### PR TITLE
Fix inconsistencies with `RVec` in respect to `Vec`

### DIFF
--- a/abi_stable/src/std_types/vec.rs
+++ b/abi_stable/src/std_types/vec.rs
@@ -1091,6 +1091,7 @@ slice_like_impl_cmp_traits! {
     Vec<U>,
     [U],
     &[U],
+    &mut [U],
     RSlice<'_, U>,
     RSliceMut<'_, U>,
 }
@@ -1123,12 +1124,27 @@ impl_into_rust_repr! {
     }
 }
 
-impl<'a, T> From<&'a [T]> for RVec<T>
+impl<T> From<&[T]> for RVec<T>
 where
     T: Clone,
 {
-    fn from(this: &'a [T]) -> Self {
+    fn from(this: &[T]) -> Self {
         this.to_vec().into()
+    }
+}
+
+impl<T> From<&mut [T]> for RVec<T>
+where
+    T: Clone,
+{
+    fn from(this: &mut [T]) -> Self {
+        this.to_vec().into()
+    }
+}
+
+impl From<&str> for RVec<u8> {
+    fn from(s: &str) -> Self {
+        From::from(s.as_bytes())
     }
 }
 
@@ -1313,6 +1329,24 @@ impl<T> Extend<T> for RVec<T> {
         self.reserve(lower);
         for elem in iter {
             self.push(elem);
+        }
+    }
+}
+
+impl<'a, T> Extend<&'a T> for RVec<T>
+where
+    T: 'a + Copy,
+{
+    fn extend<I>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = &'a T>,
+    {
+        // optimizable
+        let iter = iter.into_iter();
+        let (lower, _) = iter.size_hint();
+        self.reserve(lower);
+        for elem in iter {
+            self.push(*elem);
         }
     }
 }

--- a/abi_stable/src/std_types/vec/tests.rs
+++ b/abi_stable/src/std_types/vec/tests.rs
@@ -273,8 +273,9 @@ fn extend_from_copy_slice() {
 fn extend() {
     let mut list = RVec::new();
     let from: Vec<&str> = vec!["hello 0", "hello 1", "hello 2"];
-    list.extend([].iter().cloned());
     list.extend(from.iter().cloned());
+    let from_empty: &[&str] = &[];
+    list.extend(from_empty.iter().cloned());
     assert_eq!(&*list, &*from);
 
     let from2: Vec<&str> = vec!["fuck", "that"];


### PR DESCRIPTION
A few improvements I found while trying to fix strange lifetime errors. With this, `RVec` should be closer to `Vec`.