### PR TITLE
`halfbrown` support

### DIFF
--- a/abi_stable/Cargo.toml
+++ b/abi_stable/Cargo.toml
@@ -68,6 +68,7 @@ generational-arena = "0.2.8"
 crossbeam-channel = { version = "0.5.1", optional = true }
 serde_json = { version = "1.0.66", features = ["raw_value"], optional = true }
 paste = "1.0"
+halfbrown = { version = "0.1.12", optional = true }
 
 [dependencies.core_extensions]
 default_features=false

--- a/abi_stable/Cargo.toml
+++ b/abi_stable/Cargo.toml
@@ -68,6 +68,7 @@ generational-arena = "0.2.8"
 crossbeam-channel = { version = "0.5.1", optional = true }
 serde_json = { version = "1.0.66", features = ["raw_value"], optional = true }
 paste = "1.0"
+hashbrown = "0.12.0"
 # TODO: clean up once remove_entry is upstreamed
 halfbrown = { version = "0.1.12", git = "https://github.com/marioortizmanero/halfbrown.git", branch = "remove-entry", optional = true }
 # halfbrown = { version = "0.1.12", optional = true }

--- a/abi_stable/Cargo.toml
+++ b/abi_stable/Cargo.toml
@@ -68,7 +68,9 @@ generational-arena = "0.2.8"
 crossbeam-channel = { version = "0.5.1", optional = true }
 serde_json = { version = "1.0.66", features = ["raw_value"], optional = true }
 paste = "1.0"
-halfbrown = { version = "0.1.12", optional = true }
+# TODO: clean up once remove_entry is upstreamed
+halfbrown = { version = "0.1.12", git = "https://github.com/marioortizmanero/halfbrown.git", branch = "remove-entry", optional = true }
+# halfbrown = { version = "0.1.12", optional = true }
 
 [dependencies.core_extensions]
 default_features=false

--- a/abi_stable/src/std_types/map.rs
+++ b/abi_stable/src/std_types/map.rs
@@ -12,10 +12,10 @@ use std::{
     ptr::NonNull,
 };
 
-#[cfg(not(feature = "halfbrown"))]
-use collections::{hash_map::RandomState as DefaultHashBuilder, HashMap};
 #[cfg(feature = "halfbrown")]
 use halfbrown::{DefaultHashBuilder, HashMap};
+#[cfg(not(feature = "halfbrown"))]
+use std::collections::{hash_map::RandomState as DefaultHashBuilder, HashMap};
 
 #[allow(unused_imports)]
 use core_extensions::SelfOps;

--- a/abi_stable/src/std_types/map.rs
+++ b/abi_stable/src/std_types/map.rs
@@ -944,22 +944,46 @@ impl<'a, K, V, S: BuildHasher> IntoIterator for &'a mut RHashMap<K, V, S> {
     }
 }
 
-impl<K, V, S> From<HashMap<K, V, S>> for RHashMap<K, V, S>
+impl<K, V, S> From<std::collections::HashMap<K, V, S>> for RHashMap<K, V, S>
 where
+    K: Eq + Hash,
     S: BuildHasher,
     Self: Default,
 {
-    fn from(map: HashMap<K, V, S>) -> Self {
+    fn from(map: std::collections::HashMap<K, V, S>) -> Self {
         map.into_iter().collect()
     }
 }
 
-impl<K, V, S> From<RHashMap<K, V, S>> for HashMap<K, V, S>
+#[cfg(feature = "halfbrown")]
+impl<K, V, S> From<halfbrown::HashMap<K, V, S>> for RHashMap<K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+    Self: Default,
+{
+    fn from(map: halfbrown::HashMap<K, V, S>) -> Self {
+        map.into_iter().collect()
+    }
+}
+
+impl<K, V, S> From<RHashMap<K, V, S>> for std::collections::HashMap<K, V, S>
 where
     K: Eq + Hash,
     S: BuildHasher + Default,
 {
-    fn from(this: RHashMap<K, V, S>) -> HashMap<K, V, S> {
+    fn from(this: RHashMap<K, V, S>) -> std::collections::HashMap<K, V, S> {
+        this.into_iter().map(|x| x.into_tuple()).collect()
+    }
+}
+
+#[cfg(feature = "halfbrown")]
+impl<K, V, S> From<RHashMap<K, V, S>> for halfbrown::HashMap<K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher + Default,
+{
+    fn from(this: RHashMap<K, V, S>) -> halfbrown::HashMap<K, V, S> {
         this.into_iter().map(|x| x.into_tuple()).collect()
     }
 }

--- a/abi_stable/src/std_types/map.rs
+++ b/abi_stable/src/std_types/map.rs
@@ -3,7 +3,6 @@
 use std::{
     borrow::Borrow,
     cmp::{Eq, PartialEq},
-    collections::{hash_map::RandomState, HashMap},
     fmt::{self, Debug},
     hash::{BuildHasher, Hash, Hasher},
     iter::FromIterator,
@@ -12,6 +11,11 @@ use std::{
     ops::{Index, IndexMut},
     ptr::NonNull,
 };
+
+#[cfg(not(feature = "halfbrown"))]
+use collections::{hash_map::RandomState as DefaultHashBuilder, HashMap};
+#[cfg(feature = "halfbrown")]
+use halfbrown::{DefaultHashBuilder, HashMap};
 
 #[allow(unused_imports)]
 use core_extensions::SelfOps;
@@ -100,7 +104,7 @@ pub use self::{
     // The hasher doesn't matter
     unsafe_unconstrained(S),
 )]
-pub struct RHashMap<K, V, S = RandomState> {
+pub struct RHashMap<K, V, S = DefaultHashBuilder> {
     map: RBox<ErasedMap<K, V, S>>,
     #[sabi(unsafe_change_type = "VTable_Ref<K, V, S>")]
     vtable: PrefixRef<ErasedPrefix>,
@@ -140,7 +144,7 @@ impl<'a, K: 'a, V: 'a, S: 'a> ErasedType<'a> for ErasedMap<K, V, S> {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-impl<K, V> RHashMap<K, V, RandomState> {
+impl<K, V> RHashMap<K, V, DefaultHashBuilder> {
     /// Constructs an empty RHashMap.
     ///
     /// # Example
@@ -191,9 +195,9 @@ impl<K, V, S> RHashMap<K, V, S> {
     ///
     /// ```
     /// use abi_stable::std_types::{RHashMap, RString};
-    /// use std::collections::hash_map::RandomState;
+    /// use std::collections::hash_map::DefaultHashBuilder;
     ///
-    /// let s = RandomState::new();
+    /// let s = DefaultHashBuilder::new();
     /// let mut map = RHashMap::<RString, u32, _>::with_hasher(s);
     /// assert!(map.is_empty());
     /// map.insert("Hello".into(), 10);
@@ -215,9 +219,9 @@ impl<K, V, S> RHashMap<K, V, S> {
     ///
     /// ```
     /// use abi_stable::std_types::{RHashMap, RString};
-    /// use std::collections::hash_map::RandomState;
+    /// use std::collections::hash_map::DefaultHashBuilder;
     ///
-    /// let s = RandomState::new();
+    /// let s = DefaultHashBuilder::new();
     /// let mut map = RHashMap::<RString, u32, _>::with_capacity_and_hasher(10, s);
     /// assert!(map.capacity() >= 10);
     ///
@@ -1219,7 +1223,7 @@ struct VTable<K, V, S> {
 impl<K, V, S> VTable<K, V, S>
 where
     K: Eq + Hash,
-    S: BuildHasher,
+    S: BuildHasher + Default,
 {
     const VTABLE_VAL: WithMetadata<VTable<K, V, S>> =
         { WithMetadata::new(PrefixTypeTrait::METADATA, Self::VTABLE) };

--- a/abi_stable/src/std_types/map.rs
+++ b/abi_stable/src/std_types/map.rs
@@ -49,6 +49,11 @@ pub use self::{
     iterator_stuff::{IntoIter, MutIterInterface, RefIterInterface, ValIterInterface},
 };
 
+#[cfg(feature = "halfbrown")]
+pub use halfbrown::{Entry, OccupiedEntry, VacantEntry};
+#[cfg(not(feature = "halfbrown"))]
+pub use hashbrown::hash_map::{Entry, OccupiedEntry, VacantEntry};
+
 /// An ffi-safe hashmap, which wraps `std::collections::HashMap<K, V, S>`,
 /// only requiring the `K: Eq + Hash` bounds when constructing it.
 ///
@@ -104,7 +109,7 @@ pub use self::{
     // The hasher doesn't matter
     unsafe_unconstrained(S),
 )]
-pub struct RHashMap<K, V, S = DefaultHashBuilder> {
+pub struct RHashMap<K, V, S: BuildHasher = DefaultHashBuilder> {
     map: RBox<ErasedMap<K, V, S>>,
     #[sabi(unsafe_change_type = "VTable_Ref<K, V, S>")]
     vtable: PrefixRef<ErasedPrefix>,
@@ -112,9 +117,9 @@ pub struct RHashMap<K, V, S = DefaultHashBuilder> {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-struct BoxedHashMap<'a, K, V, S> {
+struct BoxedHashMap<'a, K, V, S: BuildHasher> {
     map: HashMap<MapKey<K>, V, S>,
-    entry: Option<BoxedREntry<'a, K, V>>,
+    entry: Option<BoxedREntry<'a, K, V, S>>,
 }
 
 /// An RHashMap iterator,
@@ -138,7 +143,7 @@ pub type Drain<'a, K, V> = DynTrait<'a, RBox<()>, ValIterInterface<K, V>>;
 )]
 struct ErasedMap<K, V, S>(PhantomData<(K, V)>, UnsafeIgnoredType<S>);
 
-impl<'a, K: 'a, V: 'a, S: 'a> ErasedType<'a> for ErasedMap<K, V, S> {
+impl<'a, K: 'a, V: 'a, S: 'a + BuildHasher> ErasedType<'a> for ErasedMap<K, V, S> {
     type Unerased = BoxedHashMap<'a, K, V, S>;
 }
 
@@ -188,7 +193,7 @@ impl<K, V> RHashMap<K, V, DefaultHashBuilder> {
     }
 }
 
-impl<K, V, S> RHashMap<K, V, S> {
+impl<K, V, S: BuildHasher> RHashMap<K, V, S> {
     /// Constructs an empty RHashMap with the passed `hash_builder` to hash the keys.
     ///
     /// # Example
@@ -243,13 +248,13 @@ impl<K, V, S> RHashMap<K, V, S> {
     }
 }
 
-impl<K, V, S> RHashMap<K, V, S> {
+impl<K, V, S: BuildHasher> RHashMap<K, V, S> {
     fn vtable(&self) -> VTable_Ref<K, V, S> {
         unsafe { VTable_Ref::<K, V, S>(self.vtable.cast()) }
     }
 }
 
-impl<K, V, S> RHashMap<K, V, S> {
+impl<K, V, S: BuildHasher> RHashMap<K, V, S> {
     /// Returns whether the map associates a value with the key.
     ///
     /// # Example
@@ -369,7 +374,7 @@ impl<K, V, S> RHashMap<K, V, S> {
     }
 }
 
-impl<K, V, S> RHashMap<K, V, S> {
+impl<K, V, S: BuildHasher> RHashMap<K, V, S> {
     /// Returns whether the map associates a value with the key.
     ///
     /// # Example
@@ -755,7 +760,7 @@ impl<K, V, S> RHashMap<K, V, S> {
     ///
     /// ```
     ///
-    pub fn entry(&mut self, key: K) -> REntry<'_, K, V> {
+    pub fn entry(&mut self, key: K) -> REntry<'_, K, V, S> {
         let vtable = self.vtable();
 
         unsafe { vtable.entry()(self.map.as_rmut(), key) }
@@ -907,7 +912,7 @@ impl<'a, K, V> Iterator for Values<'a, K, V> {
 }
 
 /// This returns an `Iterator<Item= Tuple2< K, V > >+!Send+!Sync`
-impl<K, V, S> IntoIterator for RHashMap<K, V, S> {
+impl<K, V, S: BuildHasher> IntoIterator for RHashMap<K, V, S> {
     type Item = Tuple2<K, V>;
     type IntoIter = IntoIter<K, V>;
 
@@ -919,7 +924,7 @@ impl<K, V, S> IntoIterator for RHashMap<K, V, S> {
 }
 
 /// This returns an `Iterator<Item= Tuple2< &K, &V > > + !Send + !Sync + Clone`
-impl<'a, K, V, S> IntoIterator for &'a RHashMap<K, V, S> {
+impl<'a, K, V, S: BuildHasher> IntoIterator for &'a RHashMap<K, V, S> {
     type Item = Tuple2<&'a K, &'a V>;
     type IntoIter = Iter<'a, K, V>;
 
@@ -930,7 +935,7 @@ impl<'a, K, V, S> IntoIterator for &'a RHashMap<K, V, S> {
 
 /// This returns a type that implements
 /// `Iterator<Item= Tuple2< &K, &mut V > > + !Send + !Sync`
-impl<'a, K, V, S> IntoIterator for &'a mut RHashMap<K, V, S> {
+impl<'a, K, V, S: BuildHasher> IntoIterator for &'a mut RHashMap<K, V, S> {
     type Item = Tuple2<&'a K, &'a mut V>;
     type IntoIter = IterMut<'a, K, V>;
 
@@ -941,6 +946,7 @@ impl<'a, K, V, S> IntoIterator for &'a mut RHashMap<K, V, S> {
 
 impl<K, V, S> From<HashMap<K, V, S>> for RHashMap<K, V, S>
 where
+    S: BuildHasher,
     Self: Default,
 {
     fn from(map: HashMap<K, V, S>) -> Self {
@@ -958,7 +964,7 @@ where
     }
 }
 
-impl<K, V, S> FromIterator<(K, V)> for RHashMap<K, V, S>
+impl<K, V, S: BuildHasher> FromIterator<(K, V)> for RHashMap<K, V, S>
 where
     Self: Default,
 {
@@ -972,7 +978,7 @@ where
     }
 }
 
-impl<K, V, S> FromIterator<Tuple2<K, V>> for RHashMap<K, V, S>
+impl<K, V, S: BuildHasher> FromIterator<Tuple2<K, V>> for RHashMap<K, V, S>
 where
     Self: Default,
 {
@@ -986,7 +992,7 @@ where
     }
 }
 
-impl<K, V, S> Extend<(K, V)> for RHashMap<K, V, S> {
+impl<K, V, S: BuildHasher> Extend<(K, V)> for RHashMap<K, V, S> {
     fn extend<I>(&mut self, iter: I)
     where
         I: IntoIterator<Item = (K, V)>,
@@ -999,7 +1005,7 @@ impl<K, V, S> Extend<(K, V)> for RHashMap<K, V, S> {
     }
 }
 
-impl<K, V, S> Extend<Tuple2<K, V>> for RHashMap<K, V, S> {
+impl<K, V, S: BuildHasher> Extend<Tuple2<K, V>> for RHashMap<K, V, S> {
     #[inline]
     fn extend<I>(&mut self, iter: I)
     where
@@ -1013,6 +1019,7 @@ impl<K, V, S> Default for RHashMap<K, V, S>
 where
     K: Eq + Hash,
     S: BuildHasher + Default,
+    S: BuildHasher,
 {
     fn default() -> Self {
         Self::with_hasher(S::default())
@@ -1023,6 +1030,7 @@ impl<K, V, S> Clone for RHashMap<K, V, S>
 where
     K: Clone,
     V: Clone,
+    S: BuildHasher,
     Self: Default,
 {
     fn clone(&self) -> Self {
@@ -1036,6 +1044,7 @@ impl<K, V, S> Debug for RHashMap<K, V, S>
 where
     K: Debug,
     V: Debug,
+    S: BuildHasher,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_map()
@@ -1048,6 +1057,7 @@ impl<K, V, S> Eq for RHashMap<K, V, S>
 where
     K: Eq,
     V: Eq,
+    S: BuildHasher,
 {
 }
 
@@ -1055,6 +1065,7 @@ impl<K, V, S> PartialEq for RHashMap<K, V, S>
 where
     K: PartialEq,
     V: PartialEq,
+    S: BuildHasher,
 {
     fn eq(&self, other: &Self) -> bool {
         if self.len() != other.len() {
@@ -1066,14 +1077,25 @@ where
     }
 }
 
-unsafe impl<K, V, S> Send for RHashMap<K, V, S> where HashMap<K, V, S>: Send {}
+unsafe impl<K, V, S> Send for RHashMap<K, V, S>
+where
+    HashMap<K, V, S>: Send,
+    S: BuildHasher,
+{
+}
 
-unsafe impl<K, V, S> Sync for RHashMap<K, V, S> where HashMap<K, V, S>: Sync {}
+unsafe impl<K, V, S> Sync for RHashMap<K, V, S>
+where
+    HashMap<K, V, S>: Sync,
+    S: BuildHasher,
+{
+}
 
 impl<K, Q, V, S> Index<&Q> for RHashMap<K, V, S>
 where
     K: Borrow<Q>,
     Q: Eq + Hash + ?Sized,
+    S: BuildHasher,
 {
     type Output = V;
 
@@ -1087,6 +1109,7 @@ impl<K, Q, V, S> IndexMut<&Q> for RHashMap<K, V, S>
 where
     K: Borrow<Q>,
     Q: Eq + Hash + ?Sized,
+    S: BuildHasher,
 {
     fn index_mut(&mut self, query: &Q) -> &mut V {
         self.get_mut(query)
@@ -1103,11 +1126,11 @@ mod serde {
         Deserialize, Deserializer, Serialize, Serializer,
     };
 
-    struct RHashMapVisitor<K, V, S> {
+    struct RHashMapVisitor<K, V, S: BuildHasher> {
         _marker: NonOwningPhantom<RHashMap<K, V, S>>,
     }
 
-    impl<K, V, S> RHashMapVisitor<K, V, S> {
+    impl<K, V, S: BuildHasher> RHashMapVisitor<K, V, S> {
         fn new() -> Self {
             RHashMapVisitor {
                 _marker: NonOwningPhantom::NEW,
@@ -1119,6 +1142,7 @@ mod serde {
     where
         K: Deserialize<'de>,
         V: Deserialize<'de>,
+        S: BuildHasher,
         RHashMap<K, V, S>: Default,
     {
         type Value = RHashMap<K, V, S>;
@@ -1147,6 +1171,7 @@ mod serde {
     where
         K: Deserialize<'de>,
         V: Deserialize<'de>,
+        S: BuildHasher,
         Self: Default,
     {
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -1161,6 +1186,7 @@ mod serde {
     where
         K: Serialize,
         V: Serialize,
+        S: BuildHasher,
     {
         fn serialize<Z>(&self, serializer: Z) -> Result<Z::Ok, Z::Error>
         where
@@ -1186,7 +1212,7 @@ mod serde {
     unsafe_unconstrained(S),
     //debug_print,
 )]
-struct VTable<K, V, S> {
+struct VTable<K, V, S: BuildHasher> {
     ///
     insert_elem: unsafe extern "C" fn(RMut<'_, ErasedMap<K, V, S>>, K, V) -> ROption<V>,
 
@@ -1217,7 +1243,7 @@ struct VTable<K, V, S> {
     drain: unsafe extern "C" fn(RMut<'_, ErasedMap<K, V, S>>) -> Drain<'_, K, V>,
     iter_val: unsafe extern "C" fn(RBox<ErasedMap<K, V, S>>) -> IntoIter<K, V>,
     #[sabi(last_prefix_field)]
-    entry: unsafe extern "C" fn(RMut<'_, ErasedMap<K, V, S>>, K) -> REntry<'_, K, V>,
+    entry: unsafe extern "C" fn(RMut<'_, ErasedMap<K, V, S>>, K) -> REntry<'_, K, V, S>,
 }
 
 impl<K, V, S> VTable<K, V, S>

--- a/abi_stable/src/std_types/map/entry.rs
+++ b/abi_stable/src/std_types/map/entry.rs
@@ -2,20 +2,6 @@ use super::*;
 
 use std::{hash::Hash, mem::ManuallyDrop, ptr};
 
-#[cfg(not(feature = "halfbrown"))]
-mod hashmap_impl {
-    pub use std::collections::hash_map::{Entry, OccupiedEntry, VacantEntry};
-}
-#[cfg(feature = "halfbrown")]
-mod hashmap_impl {
-    pub type OccupiedEntry<'a, K, V> =
-        halfbrown::OccupiedEntry<'a, K, V, halfbrown::DefaultHashBuilder>;
-    pub type VacantEntry<'a, K, V> =
-        halfbrown::VacantEntry<'a, K, V, halfbrown::DefaultHashBuilder>;
-    pub type Entry<'a, K, V> = halfbrown::Entry<'a, K, V, halfbrown::DefaultHashBuilder>;
-}
-use hashmap_impl::*;
-
 use crate::{
     marker_type::UnsafeIgnoredType,
     prefix_type::{PrefixTypeTrait, WithMetadata},
@@ -23,49 +9,64 @@ use crate::{
 };
 
 /// The enum stored alongside the unerased HashMap.
-pub(super) enum BoxedREntry<'a, K, V> {
-    Occupied(UnerasedOccupiedEntry<'a, K, V>),
-    Vacant(UnerasedVacantEntry<'a, K, V>),
+pub(super) enum BoxedREntry<'a, K, V, S: BuildHasher> {
+    Occupied(UnerasedOccupiedEntry<'a, K, V, S>),
+    Vacant(UnerasedVacantEntry<'a, K, V, S>),
 }
 
 /// A handle into an entry in a map, which is either vacant or occupied.
 #[derive(StableAbi)]
 #[repr(C)]
-#[sabi(bound = "K: 'a", bound = "V: 'a")]
-pub enum REntry<'a, K, V> {
-    Occupied(ROccupiedEntry<'a, K, V>),
-    Vacant(RVacantEntry<'a, K, V>),
+#[sabi(
+    bound = "K: 'a",
+    bound = "V: 'a",
+    bound = "S: 'a",
+    // The hasher doesn't matter
+    unsafe_unconstrained(S),
+)]
+pub enum REntry<'a, K, V, S: BuildHasher> {
+    Occupied(ROccupiedEntry<'a, K, V, S>),
+    Vacant(RVacantEntry<'a, K, V, S>),
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 
 #[derive(StableAbi)]
 #[repr(C)]
-struct ErasedOccupiedEntry<K, V>(PhantomData<(K, V)>);
+#[sabi(
+    // The hasher doesn't matter
+    unsafe_unconstrained(S),
+)]
+struct ErasedOccupiedEntry<K, V, S>(PhantomData<(K, V, S)>);
 
 #[derive(StableAbi)]
 #[repr(C)]
-struct ErasedVacantEntry<K, V>(PhantomData<(K, V)>);
+#[sabi(
+    // The hasher doesn't matter
+    unsafe_unconstrained(S),
+)]
+struct ErasedVacantEntry<K, V, S>(PhantomData<(K, V, S)>);
 
-type UnerasedOccupiedEntry<'a, K, V> = ManuallyDrop<OccupiedEntry<'a, MapKey<K>, V>>;
+type UnerasedOccupiedEntry<'a, K, V, S> = ManuallyDrop<OccupiedEntry<'a, MapKey<K>, V, S>>;
 
-type UnerasedVacantEntry<'a, K, V> = ManuallyDrop<VacantEntry<'a, MapKey<K>, V>>;
+type UnerasedVacantEntry<'a, K, V, S> = ManuallyDrop<VacantEntry<'a, MapKey<K>, V, S>>;
 
-impl<'a, K: 'a, V: 'a> ErasedType<'a> for ErasedOccupiedEntry<K, V> {
-    type Unerased = UnerasedOccupiedEntry<'a, K, V>;
+impl<'a, K: 'a, V: 'a, S: 'a + BuildHasher> ErasedType<'a> for ErasedOccupiedEntry<K, V, S> {
+    type Unerased = UnerasedOccupiedEntry<'a, K, V, S>;
 }
 
-impl<'a, K: 'a, V: 'a> ErasedType<'a> for ErasedVacantEntry<K, V> {
-    type Unerased = UnerasedVacantEntry<'a, K, V>;
+impl<'a, K: 'a, V: 'a, S: 'a + BuildHasher> ErasedType<'a> for ErasedVacantEntry<K, V, S> {
+    type Unerased = UnerasedVacantEntry<'a, K, V, S>;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 
-impl<'a, K, V> From<Entry<'a, MapKey<K>, V>> for BoxedREntry<'a, K, V>
+impl<'a, K, V, S> From<Entry<'a, MapKey<K>, V, S>> for BoxedREntry<'a, K, V, S>
 where
     K: Eq + Hash,
+    S: BuildHasher,
 {
-    fn from(entry: Entry<'a, MapKey<K>, V>) -> Self {
+    fn from(entry: Entry<'a, MapKey<K>, V, S>) -> Self {
         match entry {
             Entry::Occupied(entry) => entry.piped(ManuallyDrop::new).piped(BoxedREntry::Occupied),
             Entry::Vacant(entry) => entry.piped(ManuallyDrop::new).piped(BoxedREntry::Vacant),
@@ -73,11 +74,12 @@ where
     }
 }
 
-impl<'a, K, V> REntry<'a, K, V>
+impl<'a, K, V, S> REntry<'a, K, V, S>
 where
     K: Eq + Hash,
+    S: BuildHasher,
 {
-    pub(super) unsafe fn new(entry: &'a mut BoxedREntry<'a, K, V>) -> Self {
+    pub(super) unsafe fn new(entry: &'a mut BoxedREntry<'a, K, V, S>) -> Self {
         match entry {
             BoxedREntry::Occupied(entry) => {
                 entry.piped(ROccupiedEntry::new).piped(REntry::Occupied)
@@ -89,7 +91,7 @@ where
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 
-impl<'a, K, V> REntry<'a, K, V> {
+impl<'a, K, V, S: BuildHasher> REntry<'a, K, V, S> {
     /// Returns a reference to the value in the entry.
     ///
     /// # Example
@@ -261,10 +263,11 @@ impl<'a, K, V> REntry<'a, K, V> {
     }
 }
 
-impl<K, V> Debug for REntry<'_, K, V>
+impl<K, V, S> Debug for REntry<'_, K, V, S>
 where
     K: Debug,
     V: Debug,
+    S: BuildHasher,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -279,38 +282,50 @@ where
 /// A handle into an occupied entry in a map.
 #[derive(StableAbi)]
 #[repr(C)]
-#[sabi(bound = "K: 'a", bound = "V: 'a")]
-pub struct ROccupiedEntry<'a, K, V> {
-    entry: RMut<'a, ErasedOccupiedEntry<K, V>>,
-    vtable: OccupiedVTable_Ref<K, V>,
-    _marker: UnsafeIgnoredType<OccupiedEntry<'a, K, V>>,
+#[sabi(
+    bound = "K: 'a",
+    bound = "V: 'a",
+    bound = "S: 'a",
+    // The hasher doesn't matter
+    unsafe_unconstrained(S),
+)]
+pub struct ROccupiedEntry<'a, K, V, S: BuildHasher> {
+    entry: RMut<'a, ErasedOccupiedEntry<K, V, S>>,
+    vtable: OccupiedVTable_Ref<K, V, S>,
+    _marker: UnsafeIgnoredType<OccupiedEntry<'a, K, V, S>>,
 }
 
 /// A handle into a vacant entry in a map.
 #[derive(StableAbi)]
 #[repr(C)]
-#[sabi(bound = "K: 'a", bound = "V: 'a")]
-pub struct RVacantEntry<'a, K, V> {
-    entry: RMut<'a, ErasedVacantEntry<K, V>>,
-    vtable: VacantVTable_Ref<K, V>,
-    _marker: UnsafeIgnoredType<VacantEntry<'a, K, V>>,
+#[sabi(
+    bound = "K: 'a",
+    bound = "V: 'a",
+    bound = "S: 'a",
+    // The hasher doesn't matter
+    unsafe_unconstrained(S),
+)]
+pub struct RVacantEntry<'a, K, V, S: BuildHasher> {
+    entry: RMut<'a, ErasedVacantEntry<K, V, S>>,
+    vtable: VacantVTable_Ref<K, V, S>,
+    _marker: UnsafeIgnoredType<VacantEntry<'a, K, V, S>>,
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 
-impl<'a, K, V> ROccupiedEntry<'a, K, V> {
-    fn vtable(&self) -> OccupiedVTable_Ref<K, V> {
+impl<'a, K, V, S: BuildHasher> ROccupiedEntry<'a, K, V, S> {
+    fn vtable(&self) -> OccupiedVTable_Ref<K, V, S> {
         self.vtable
     }
 }
 
-impl<'a, K, V> ROccupiedEntry<'a, K, V> {
-    fn into_inner(self) -> RMut<'a, ErasedOccupiedEntry<K, V>> {
+impl<'a, K, V, S: BuildHasher> ROccupiedEntry<'a, K, V, S> {
+    fn into_inner(self) -> RMut<'a, ErasedOccupiedEntry<K, V, S>> {
         let mut this = ManuallyDrop::new(self);
-        unsafe { ((&mut this.entry) as *mut RMut<'a, ErasedOccupiedEntry<K, V>>).read() }
+        unsafe { ((&mut this.entry) as *mut RMut<'a, ErasedOccupiedEntry<K, V, S>>).read() }
     }
 
-    pub(super) fn new(entry: &'a mut UnerasedOccupiedEntry<'a, K, V>) -> Self {
+    pub(super) fn new(entry: &'a mut UnerasedOccupiedEntry<'a, K, V, S>) -> Self {
         unsafe {
             Self {
                 entry: ErasedOccupiedEntry::from_unerased(entry),
@@ -485,7 +500,7 @@ impl<'a, K, V> ROccupiedEntry<'a, K, V> {
     }
 }
 
-impl<K, V> Debug for ROccupiedEntry<'_, K, V>
+impl<K, V, S: BuildHasher> Debug for ROccupiedEntry<'_, K, V, S>
 where
     K: Debug,
     V: Debug,
@@ -498,7 +513,7 @@ where
     }
 }
 
-impl<'a, K, V> Drop for ROccupiedEntry<'a, K, V> {
+impl<'a, K, V, S: BuildHasher> Drop for ROccupiedEntry<'a, K, V, S> {
     fn drop(&mut self) {
         let vtable = self.vtable();
 
@@ -510,19 +525,19 @@ impl<'a, K, V> Drop for ROccupiedEntry<'a, K, V> {
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 
-impl<'a, K, V> RVacantEntry<'a, K, V> {
-    fn vtable(&self) -> VacantVTable_Ref<K, V> {
+impl<'a, K, V, S: BuildHasher> RVacantEntry<'a, K, V, S> {
+    fn vtable(&self) -> VacantVTable_Ref<K, V, S> {
         self.vtable
     }
 }
 
-impl<'a, K, V> RVacantEntry<'a, K, V> {
-    fn into_inner(self) -> RMut<'a, ErasedVacantEntry<K, V>> {
+impl<'a, K, V, S: BuildHasher> RVacantEntry<'a, K, V, S> {
+    fn into_inner(self) -> RMut<'a, ErasedVacantEntry<K, V, S>> {
         let mut this = ManuallyDrop::new(self);
-        unsafe { ((&mut this.entry) as *mut RMut<'a, ErasedVacantEntry<K, V>>).read() }
+        unsafe { ((&mut this.entry) as *mut RMut<'a, ErasedVacantEntry<K, V, S>>).read() }
     }
 
-    pub(super) fn new(entry: &'a mut UnerasedVacantEntry<'a, K, V>) -> Self
+    pub(super) fn new(entry: &'a mut UnerasedVacantEntry<'a, K, V, S>) -> Self
     where
         K: Eq + Hash,
     {
@@ -617,7 +632,7 @@ impl<'a, K, V> RVacantEntry<'a, K, V> {
     }
 }
 
-impl<K, V> Debug for RVacantEntry<'_, K, V>
+impl<K, V, S: BuildHasher> Debug for RVacantEntry<'_, K, V, S>
 where
     K: Debug,
 {
@@ -628,7 +643,7 @@ where
     }
 }
 
-impl<'a, K, V> Drop for RVacantEntry<'a, K, V> {
+impl<'a, K, V, S: BuildHasher> Drop for RVacantEntry<'a, K, V, S> {
     fn drop(&mut self) {
         let vtable = self.vtable();
 
@@ -640,26 +655,31 @@ impl<'a, K, V> Drop for RVacantEntry<'a, K, V> {
 
 #[derive(StableAbi)]
 #[repr(C)]
-#[sabi(kind(Prefix), missing_field(panic))]
-pub struct OccupiedVTable<K, V> {
-    drop_entry: unsafe extern "C" fn(RMut<'_, ErasedOccupiedEntry<K, V>>),
-    key: extern "C" fn(RRef<'_, ErasedOccupiedEntry<K, V>>) -> &K,
-    get_elem: extern "C" fn(RRef<'_, ErasedOccupiedEntry<K, V>>) -> &V,
-    get_mut_elem: extern "C" fn(RMut<'_, ErasedOccupiedEntry<K, V>>) -> &mut V,
-    fn_into_mut_elem: extern "C" fn(ROccupiedEntry<'_, K, V>) -> &'_ mut V,
-    insert_elem: extern "C" fn(RMut<'_, ErasedOccupiedEntry<K, V>>, V) -> V,
-    remove: extern "C" fn(ROccupiedEntry<'_, K, V>) -> V,
+#[sabi(
+    kind(Prefix),
+    missing_field(panic),
+    // The hasher doesn't matter
+    unsafe_unconstrained(S),
+)]
+pub struct OccupiedVTable<K, V, S: BuildHasher> {
+    drop_entry: unsafe extern "C" fn(RMut<'_, ErasedOccupiedEntry<K, V, S>>),
+    key: extern "C" fn(RRef<'_, ErasedOccupiedEntry<K, V, S>>) -> &K,
+    get_elem: extern "C" fn(RRef<'_, ErasedOccupiedEntry<K, V, S>>) -> &V,
+    get_mut_elem: extern "C" fn(RMut<'_, ErasedOccupiedEntry<K, V, S>>) -> &mut V,
+    fn_into_mut_elem: extern "C" fn(ROccupiedEntry<'_, K, V, S>) -> &'_ mut V,
+    insert_elem: extern "C" fn(RMut<'_, ErasedOccupiedEntry<K, V, S>>, V) -> V,
+    remove: extern "C" fn(ROccupiedEntry<'_, K, V, S>) -> V,
 }
 
-impl<K, V> OccupiedVTable<K, V> {
-    const VTABLE_REF: OccupiedVTable_Ref<K, V> = OccupiedVTable_Ref(Self::WM_VTABLE.as_prefix());
+impl<K, V, S: BuildHasher> OccupiedVTable<K, V, S> {
+    const VTABLE_REF: OccupiedVTable_Ref<K, V, S> = OccupiedVTable_Ref(Self::WM_VTABLE.as_prefix());
 
     staticref! {
-        const WM_VTABLE: WithMetadata<OccupiedVTable<K, V>> =
+        const WM_VTABLE: WithMetadata<OccupiedVTable<K, V, S>> =
             WithMetadata::new(PrefixTypeTrait::METADATA, Self::VTABLE)
     }
 
-    const VTABLE: OccupiedVTable<K, V> = OccupiedVTable {
+    const VTABLE: OccupiedVTable<K, V, S> = OccupiedVTable {
         drop_entry: ErasedOccupiedEntry::drop_entry,
         key: ErasedOccupiedEntry::key,
         get_elem: ErasedOccupiedEntry::get_elem,
@@ -670,7 +690,7 @@ impl<K, V> OccupiedVTable<K, V> {
     };
 }
 
-impl<K, V> ErasedOccupiedEntry<K, V> {
+impl<K, V, S: BuildHasher> ErasedOccupiedEntry<K, V, S> {
     unsafe extern "C" fn drop_entry(this: RMut<'_, Self>) {
         extern_fn_panic_handling! {
             Self::run_downcast_as_mut(this, |this|{
@@ -708,7 +728,7 @@ impl<K, V> ErasedOccupiedEntry<K, V> {
             }
         }
     }
-    extern "C" fn fn_into_mut_elem(this: ROccupiedEntry<'_, K, V>) -> &'_ mut V {
+    extern "C" fn fn_into_mut_elem(this: ROccupiedEntry<'_, K, V, S>) -> &'_ mut V {
         unsafe {
             extern_fn_panic_handling! {
                 Self::run_downcast_as_mut(
@@ -728,7 +748,7 @@ impl<K, V> ErasedOccupiedEntry<K, V> {
             }
         }
     }
-    extern "C" fn remove(this: ROccupiedEntry<'_, K, V>) -> V {
+    extern "C" fn remove(this: ROccupiedEntry<'_, K, V, S>) -> V {
         unsafe {
             extern_fn_panic_handling! {
                 Self::run_downcast_as_mut(
@@ -744,26 +764,32 @@ impl<K, V> ErasedOccupiedEntry<K, V> {
 
 #[derive(StableAbi)]
 #[repr(C)]
-#[sabi(kind(Prefix), missing_field(panic))]
-pub struct VacantVTable<K, V> {
-    drop_entry: unsafe extern "C" fn(RMut<'_, ErasedVacantEntry<K, V>>),
-    key: extern "C" fn(RRef<'_, ErasedVacantEntry<K, V>>) -> &K,
-    fn_into_key: extern "C" fn(RVacantEntry<'_, K, V>) -> K,
-    insert_elem: extern "C" fn(RVacantEntry<'_, K, V>, V) -> &'_ mut V,
+#[sabi(
+    kind(Prefix),
+    missing_field(panic),
+    // The hasher doesn't matter
+    unsafe_unconstrained(S),
+)]
+pub struct VacantVTable<K, V, S: BuildHasher> {
+    drop_entry: unsafe extern "C" fn(RMut<'_, ErasedVacantEntry<K, V, S>>),
+    key: extern "C" fn(RRef<'_, ErasedVacantEntry<K, V, S>>) -> &K,
+    fn_into_key: extern "C" fn(RVacantEntry<'_, K, V, S>) -> K,
+    insert_elem: extern "C" fn(RVacantEntry<'_, K, V, S>, V) -> &'_ mut V,
 }
 
-impl<K, V> VacantVTable<K, V>
+impl<K, V, S> VacantVTable<K, V, S>
 where
     K: Hash,
+    S: BuildHasher,
 {
-    const VTABLE_REF: VacantVTable_Ref<K, V> = VacantVTable_Ref(Self::WM_VTABLE.as_prefix());
+    const VTABLE_REF: VacantVTable_Ref<K, V, S> = VacantVTable_Ref(Self::WM_VTABLE.as_prefix());
 
     staticref! {
-        const WM_VTABLE: WithMetadata<VacantVTable<K, V>> =
+        const WM_VTABLE: WithMetadata<VacantVTable<K, V, S>> =
             WithMetadata::new(PrefixTypeTrait::METADATA, Self::VTABLE)
     }
 
-    const VTABLE: VacantVTable<K, V> = VacantVTable {
+    const VTABLE: VacantVTable<K, V, S> = VacantVTable {
         drop_entry: ErasedVacantEntry::drop_entry,
         key: ErasedVacantEntry::key,
         fn_into_key: ErasedVacantEntry::fn_into_key,
@@ -771,9 +797,10 @@ where
     };
 }
 
-impl<K, V> ErasedVacantEntry<K, V>
+impl<K, V, S> ErasedVacantEntry<K, V, S>
 where
     K: Hash,
+    S: BuildHasher,
 {
     unsafe extern "C" fn drop_entry(this: RMut<'_, Self>) {
         extern_fn_panic_handling! {
@@ -792,7 +819,7 @@ where
             }
         }
     }
-    extern "C" fn fn_into_key(this: RVacantEntry<'_, K, V>) -> K {
+    extern "C" fn fn_into_key(this: RVacantEntry<'_, K, V, S>) -> K {
         unsafe {
             extern_fn_panic_handling! {
                 Self::run_downcast_as_mut(
@@ -802,7 +829,7 @@ where
             }
         }
     }
-    extern "C" fn insert_elem(this: RVacantEntry<'_, K, V>, elem: V) -> &'_ mut V {
+    extern "C" fn insert_elem(this: RVacantEntry<'_, K, V, S>, elem: V) -> &'_ mut V {
         unsafe {
             extern_fn_panic_handling! {
                 Self::run_downcast_as_mut(

--- a/abi_stable/src/std_types/map/entry.rs
+++ b/abi_stable/src/std_types/map/entry.rs
@@ -37,7 +37,7 @@ pub enum REntry<'a, K, V, S: BuildHasher> {
     // The hasher doesn't matter
     unsafe_unconstrained(S),
 )]
-struct ErasedOccupiedEntry<K, V, S>(PhantomData<(K, V, S)>);
+struct ErasedOccupiedEntry<K, V, S: BuildHasher>(PhantomData<(K, V)>, UnsafeIgnoredType<S>);
 
 #[derive(StableAbi)]
 #[repr(C)]
@@ -45,7 +45,7 @@ struct ErasedOccupiedEntry<K, V, S>(PhantomData<(K, V, S)>);
     // The hasher doesn't matter
     unsafe_unconstrained(S),
 )]
-struct ErasedVacantEntry<K, V, S>(PhantomData<(K, V, S)>);
+struct ErasedVacantEntry<K, V, S: BuildHasher>(PhantomData<(K, V)>, UnsafeIgnoredType<S>);
 
 type UnerasedOccupiedEntry<'a, K, V, S> = ManuallyDrop<OccupiedEntry<'a, MapKey<K>, V, S>>;
 

--- a/abi_stable/src/std_types/map/extern_fns.rs
+++ b/abi_stable/src/std_types/map/extern_fns.rs
@@ -71,19 +71,12 @@ where
         this: RMut<'_, Self>,
         key: MapQuery<'_, K>,
     ) -> ROption<Tuple2<K, V>> {
-        #[cfg(not(feature = "halfbrown"))]
-        {
-            Self::run_mut(this, |this| {
-                match this.map.remove_entry(unsafe { &key.as_mapkey() }) {
-                    Some(x) => RSome(Tuple2(x.0.into_inner(), x.1)),
-                    None => RNone,
-                }
-            })
-        }
-
-        // TODO
-        #[cfg(feature = "halfbrown")]
-        RNone
+        Self::run_mut(this, |this| {
+            match this.map.remove_entry(unsafe { &key.as_mapkey() }) {
+                Some(x) => RSome(Tuple2(x.0.into_inner(), x.1)),
+                None => RNone,
+            }
+        })
     }
 
     pub(super) unsafe extern "C" fn get_elem_p<'a>(this: RRef<'a, Self>, key: &K) -> Option<&'a V> {
@@ -101,17 +94,10 @@ where
         this: RMut<'_, Self>,
         key: &K,
     ) -> ROption<Tuple2<K, V>> {
-        #[cfg(not(feature = "halfbrown"))]
-        {
-            Self::run_mut(this, |this| match this.map.remove_entry(key) {
-                Some(x) => RSome(Tuple2(x.0.into_inner(), x.1)),
-                None => RNone,
-            })
-        }
-
-        // TODO
-        #[cfg(not(feature = "halfbrown"))]
-        RNone
+        Self::run_mut(this, |this| match this.map.remove_entry(key) {
+            Some(x) => RSome(Tuple2(x.0.into_inner(), x.1)),
+            None => RNone,
+        })
     }
 
     pub(super) unsafe extern "C" fn reserve(this: RMut<'_, Self>, reserved: usize) {

--- a/abi_stable/src/std_types/map/extern_fns.rs
+++ b/abi_stable/src/std_types/map/extern_fns.rs
@@ -36,6 +36,7 @@ where
         F: FnOnce(RBox<BoxedHashMap<'a, K, V, S>>) -> R,
         K: 'a,
         V: 'a,
+        S: 'a,
     {
         extern_fn_panic_handling! {
             let map = this.transmute_element::<BoxedHashMap<'a, K, V, S>>();
@@ -149,7 +150,7 @@ where
         })
     }
 
-    pub(super) unsafe extern "C" fn entry(this: RMut<'_, Self>, key: K) -> REntry<'_, K, V> {
+    pub(super) unsafe extern "C" fn entry(this: RMut<'_, Self>, key: K) -> REntry<'_, K, V, S> {
         Self::run_mut(this, |this| {
             this.entry = None;
             let map = &mut this.map;

--- a/abi_stable/src/std_types/map/test.rs
+++ b/abi_stable/src/std_types/map/test.rs
@@ -6,7 +6,8 @@ use fnv::FnvBuildHasher as FnVBH;
 
 use crate::std_types::RString;
 
-type DefaultBH = RandomState;
+// TODO: remove?
+type DefaultBH = DefaultHashBuilder;
 
 fn _covariant_hashmap<'a: 'b, 'b, T>(foo: HashMap<&'a T, &'a T>) -> HashMap<&'b T, &'b T> {
     foo

--- a/abi_stable/src/std_types/map/test.rs
+++ b/abi_stable/src/std_types/map/test.rs
@@ -6,7 +6,6 @@ use fnv::FnvBuildHasher as FnVBH;
 
 use crate::std_types::RString;
 
-// TODO: remove?
 type DefaultBH = DefaultHashBuilder;
 
 fn _covariant_hashmap<'a: 'b, 'b, T>(foo: HashMap<&'a T, &'a T>) -> HashMap<&'b T, &'b T> {


### PR DESCRIPTION
This PR adds support for [`halfbrown`](https://crates.io/crates/halfbrown), a more performant implementation of `hashbrown`:

> Hashmap implementation that dynamically switches from a vector based backend to a hashbrown based backend as the number of keys grows

This PR adds a feature that makes the underlying struct for `RHashMap` a `halfmap::HashMap` when activated. Its interface is meant to be the same as `hashbrown`'s. This required actually using `hashbrown` instead of `std::collections`, since their interface is slightly different.

The only error I haven't been able to fix is the following, any help?

```
error[E0271]: type mismatch resolving `<iterator_stuff::RefIterInterface<K, V> as erased_types::traits::InterfaceType>::Clone == impl_enum::Unimplemented<type_leve
l::trait_marker::Clone>`
   --> abi_stable/src/std_types/map/extern_fns.rs:123:13
    |
123 |             DynTrait::from_borrowing_value(iter, RefIterInterface::NEW)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `impl_enum::Unimplemented`, found struct `impl_enum::Implemented`
    |
    = note: expected struct `impl_enum::Unimplemented<type_level::trait_marker::Clone>`
               found struct `impl_enum::Implemented<type_level::trait_marker::Clone>`
note: required because of the requirements on the impl of `erased_types::vtable::GetVtable<'_, std::iter::Map<halfbrown::Iter<'_, map_key::MapKey<K>, V>, fn((&map_
key::MapKey<K>, &V)) -> tuple::Tuple2<&K, &V> {map_iter_ref::<'_, K, &V>}>, std_types::boxed::private::RBox<()>, std_types::boxed::private::RBox<std::iter::Map<hal
fbrown::Iter<'_, map_key::MapKey<K>, V>, fn((&map_key::MapKey<K>, &V)) -> tuple::Tuple2<&K, &V> {map_iter_ref::<'_, K, &V>}>>, iterator_stuff::RefIterInterface<K,
V>>` for `interface_for::InterfaceFor<std::iter::Map<halfbrown::Iter<'_, map_key::MapKey<K>, V>, fn((&map_key::MapKey<K>, &V)) -> tuple::Tuple2<&K, &V> {map_iter_r
ef::<'_, K, &V>}>, iterator_stuff::RefIterInterface<K, V>, downcasting::TD_Opaque>`
   --> abi_stable/src/erased_types/vtable.rs:333:13
    |
333 |               GetVtable<'borr,$value,$erased_ptr,$orig_ptr,$interf>
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
334 |           for This
    |               ^^^^
...
495 |   declare_meta_vtable! {
    |  _-
    | |_|
    | |
496 | |     interface=I;
497 | |     value  =T;
498 | |     erased_pointer=ErasedPtr;
...   |
757 | |     ]
758 | | }
    | | -
    | |_|
    | |_in this macro invocation
    |   in this macro invocation
note: required by a bound in `priv_::DynTrait::<'static, rref::RRef<'static, ()>, ()>::from_borrowing_value`
   --> abi_stable/src/erased_types/dyn_trait.rs:877:44
    |
870 |         pub fn from_borrowing_value<'borr, T, I>(
    |                -------------------- required by a bound in this
...
877 |             InterfaceFor<T, I, TD_Opaque>: GetVtable<'borr, T, RBox<()>, RBox<T>, I>,
    |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `priv_::DynTrait::<'static, rref::RRef<'static
, ()>, ()>::from_borrowing_value`
    = note: this error originates in the macro `declare_meta_vtable` (in Nightly builds, run with -Z macro-backtrace for more info)
```