### PR TITLE
Fix hasher

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,10 +38,6 @@ jobs:
         cargo fmt -- --check
 
     - name: enable-rust-stable
-      if: matrix.rust == '1.51.0' 
-      run: echo "rustv=rust_1_51" >> $GITHUB_ENV
-
-    - name: enable-rust-stable
       if: matrix.rust == '1.56.0' 
       run: echo "rustv=rust_1_56" >> $GITHUB_ENV
 

--- a/abi_stable/src/erased_types/trait_objects.rs
+++ b/abi_stable/src/erased_types/trait_objects.rs
@@ -84,13 +84,6 @@ impl<'a> Hasher for HasherObject<'a> {
         (u8, write_u8),
         (usize, write_usize)
     );
-
-    fn write_i128(&mut self, val: i128) {
-        todo!()
-    }
-    fn write_u128(&mut self, val: u128) {
-        todo!()
-    }
 }
 
 /// The write variations for the hasher. Even if `write` is the only required

--- a/abi_stable/src/erased_types/trait_objects.rs
+++ b/abi_stable/src/erased_types/trait_objects.rs
@@ -21,7 +21,21 @@ use crate::{
 #[derive(StableAbi)]
 pub struct HasherObject<'a> {
     this: RMut<'a, ErasedObject>,
-    hash_slice: unsafe extern "C" fn(RMut<'_, ErasedObject>, RSlice<'_, u8>),
+    write: unsafe extern "C" fn(RMut<'_, ErasedObject>, RSlice<'_, u8>),
+    // No c-compatible layout for i128 yet
+    // write_i128: unsafe extern "C" fn(RMut<'_, ErasedObject>, i128),
+    write_i16: unsafe extern "C" fn(RMut<'_, ErasedObject>, i16),
+    write_i32: unsafe extern "C" fn(RMut<'_, ErasedObject>, i32),
+    write_i64: unsafe extern "C" fn(RMut<'_, ErasedObject>, i64),
+    write_i8: unsafe extern "C" fn(RMut<'_, ErasedObject>, i8),
+    write_isize: unsafe extern "C" fn(RMut<'_, ErasedObject>, isize),
+    // No c-compatible layout for u128 yet
+    // write_u128: unsafe extern "C" fn(RMut<'_, ErasedObject>, u128),
+    write_u16: unsafe extern "C" fn(RMut<'_, ErasedObject>, u16),
+    write_u32: unsafe extern "C" fn(RMut<'_, ErasedObject>, u32),
+    write_u64: unsafe extern "C" fn(RMut<'_, ErasedObject>, u64),
+    write_u8: unsafe extern "C" fn(RMut<'_, ErasedObject>, u8),
+    write_usize: unsafe extern "C" fn(RMut<'_, ErasedObject>, usize),
     finish: unsafe extern "C" fn(RRef<'_, ErasedObject>) -> u64,
 }
 
@@ -36,7 +50,17 @@ impl<'a> HasherObject<'a> {
                 // The lifetime is tied to the input.
                 this.transmute_element::<ErasedObject>()
             },
-            hash_slice: hash_slice_Hasher::<T>,
+            write: write_Hasher::<T>,
+            write_i16: write_i16_Hasher::<T>,
+            write_i32: write_i32_Hasher::<T>,
+            write_i64: write_i64_Hasher::<T>,
+            write_i8: write_i8_Hasher::<T>,
+            write_isize: write_isize_Hasher::<T>,
+            write_u16: write_u16_Hasher::<T>,
+            write_u32: write_u32_Hasher::<T>,
+            write_u64: write_u64_Hasher::<T>,
+            write_u8: write_u8_Hasher::<T>,
+            write_usize: write_usize_Hasher::<T>,
             finish: finish_Hasher::<T>,
         }
     }
@@ -45,9 +69,29 @@ impl<'a> HasherObject<'a> {
     pub fn as_mut<'b: 'a>(&'b mut self) -> HasherObject<'b> {
         Self {
             this: self.this.reborrow(),
-            hash_slice: self.hash_slice,
+            write: self.write,
+            write_i16: self.write_i16,
+            write_i32: self.write_i32,
+            write_i64: self.write_i64,
+            write_i8: self.write_i8,
+            write_isize: self.write_isize,
+            write_u16: self.write_u16,
+            write_u32: self.write_u32,
+            write_u64: self.write_u64,
+            write_u8: self.write_u8,
+            write_usize: self.write_usize,
             finish: self.finish,
         }
+    }
+}
+
+macro_rules! impl_write {
+    ( $(($ty:ty, $fn:ident)),* ) => {
+        $(
+            fn $fn(&mut self, val: $ty) {
+                unsafe { (self.$fn)(self.this.reborrow(), val) }
+            }
+        )*
     }
 }
 
@@ -56,7 +100,27 @@ impl<'a> Hasher for HasherObject<'a> {
         unsafe { (self.finish)(self.this.as_rref()) }
     }
     fn write(&mut self, bytes: &[u8]) {
-        unsafe { (self.hash_slice)(self.this.reborrow(), bytes.into()) }
+        unsafe { (self.write)(self.this.reborrow(), bytes.into()) }
+    }
+
+    impl_write!(
+        (i16, write_i16),
+        (i32, write_i32),
+        (i64, write_i64),
+        (i8, write_i8),
+        (isize, write_isize),
+        (u16, write_u16),
+        (u32, write_u32),
+        (u64, write_u64),
+        (u8, write_u8),
+        (usize, write_usize)
+    );
+
+    fn write_i128(&mut self, val: i128) {
+        todo!()
+    }
+    fn write_u128(&mut self, val: u128) {
+        todo!()
     }
 }
 

--- a/examples/1_trait_objects/interface/src/which_plugin.rs
+++ b/examples/1_trait_objects/interface/src/which_plugin.rs
@@ -82,7 +82,7 @@ impl WhichPlugin {
         let splitted = s
             .splitn(2, ':')
             .map(|s| s.trim())
-            .collect::<ArrayVec<[&str; 2]>>();
+            .collect::<ArrayVec<&str, 2>>();
         let named = splitted
             .get(0)
             .filter(|s| !s.is_empty())

--- a/testing/version_compatibility/impl_0/Cargo.toml
+++ b/testing/version_compatibility/impl_0/Cargo.toml
@@ -12,7 +12,8 @@ abi_stable={path="../../../abi_stable",package="abi_stable"}
 [dependencies.version_compatibility_interface]
 version="0.1"
 path="../interface/"
-features=["old"]
+# TODO: change back to "old" in the 0.11.1 release
+features=["new"]
 
 [lib]
 name = "version_compatibility_impl"


### PR DESCRIPTION
This PR finally fixes what I was experiencing in #83.

Turns out that the `HasherObject` implementation assumes that, in `Hasher`,  all the `write_TYPE` functions delegate their implementation to `write`. As in, it is only necessary to have an FFI-safe callback for `write`. This is true [in the standard library](https://doc.rust-lang.org/std/collections/hash_map/struct.DefaultHasher.html#impl-Hasher), where `write_u8` and similars rely on the default implementation of the `Hasher` trait. However, as soon as the hasher is changed to one that doesn't do this, `HasherObject` stops working as intended.

The [`AHash` hasher](https://docs.rs/ahash/latest/ahash/struct.AHasher.html#impl-Hasher) overrides `write_TYPE` so that, for example, `write_u8` delegates to `write_u64` instead of `write` for performance reasons. If someone hashes a `u8` with `Hasher` and then with `HasherObject`, they will be different. `Hasher` will call `write_u64`, but `HasherObject` will call `write`.

This issue propagated to other structs like `MapKey` or `MapQuery`, breaking more parts of `abi_stable`. It can be fixed by just implementing each `write_TYPE` function in `HasherObject`, rather than just `write`.

The only part that's left is implementing the `write_{i,u}128` functions, for which I would love to have your opinion, @rodrimati1992. Should I implement them as opaque types somehow (not sure if that would be possible)? Or do I throw a `panic!` in there indicating that it's unsupported?

Thanks to @darach, @Licenser, and @mfelsche for their help in solving this issue!