### PR TITLE
The scope of the unsafe block can be appropriately reduced

### DIFF
--- a/abi_stable/src/external_types/crossbeam_channel/extern_fns.rs
+++ b/abi_stable/src/external_types/crossbeam_channel/extern_fns.rs
@@ -9,8 +9,8 @@ macro_rules! shared_fns {
     ) => {
         impl<T> $erased<T> {
             pub(super) fn from_unerased_value(value: $unerased<T>) -> RBox<Self> {
+                let boxed = RBox::new(value);
                 unsafe {
-                    let boxed = RBox::new(value);
                     ErasedType::from_unerased(boxed)
                 }
             }

--- a/abi_stable/src/pointer_trait.rs
+++ b/abi_stable/src/pointer_trait.rs
@@ -699,8 +699,8 @@ pub unsafe trait OwnedPointer: Sized + AsMutPtr + GetPointerKind {
     where
         F: FnOnce(MovePtr<'_, Self::PtrTarget>) -> R,
     {
+        let guard = DropAllocationMutGuard(&mut this);
         unsafe {
-            let guard = DropAllocationMutGuard(&mut this);
             func(Self::get_move_ptr(guard.0))
         }
     }
@@ -735,8 +735,8 @@ pub unsafe trait OwnedPointer: Sized + AsMutPtr + GetPointerKind {
     where
         F: FnOnce(MovePtr<'_, Self::PtrTarget>) -> R,
     {
+        let mut guard = DropAllocationGuard(ManuallyDrop::new(self));
         unsafe {
-            let mut guard = DropAllocationGuard(ManuallyDrop::new(self));
             func(Self::get_move_ptr(&mut guard.0))
         }
     }

--- a/abi_stable/src/sabi_types/move_ptr.rs
+++ b/abi_stable/src/sabi_types/move_ptr.rs
@@ -289,8 +289,8 @@ impl<'a, T> MovePtr<'a, T> {
     /// ```
     #[inline]
     pub fn into_box(this: Self) -> Box<T> {
+        let raw = Self::into_raw(this);
         unsafe {
-            let raw = Self::into_raw(this);
 
             if std::mem::size_of::<T>() == 0 {
                 Box::from_raw(raw)

--- a/abi_stable/src/std_types/boxed.rs
+++ b/abi_stable/src/std_types/boxed.rs
@@ -216,9 +216,9 @@ impl<T> RBox<T> {
     pub fn into_box(this: Self) -> Box<T> {
         let this = ManuallyDrop::new(this);
 
+        let this_vtable = this.vtable();
+        let other_vtable = VTableGetter::LIB_VTABLE;
         unsafe {
-            let this_vtable = this.vtable();
-            let other_vtable = VTableGetter::LIB_VTABLE;
             if ::std::ptr::eq(this_vtable.0.to_raw_ptr(), other_vtable.0.to_raw_ptr())
                 || this_vtable.type_id() == other_vtable.type_id()
             {
@@ -596,9 +596,9 @@ where
 
 impl<T> Drop for RBox<T> {
     fn drop(&mut self) {
+        let data = self.data();
+        let dstr = RBox::vtable(self).destructor();
         unsafe {
-            let data = self.data();
-            let dstr = RBox::vtable(self).destructor();
             dstr(data as *mut (), CallReferentDrop::Yes, Deallocate::Yes);
         }
     }

--- a/abi_stable/src/std_types/map.rs
+++ b/abi_stable/src/std_types/map.rs
@@ -1223,10 +1223,10 @@ where
     const VTABLE_REF: VTable_Ref<K, V, S> = unsafe { VTable_Ref(Self::VTABLE_VAL.as_prefix()) };
 
     fn erased_map(hash_builder: S) -> RBox<ErasedMap<K, V, S>> {
+        let map = HashMap::<MapKey<K>, V, S>::with_hasher(hash_builder);
+        let boxed = BoxedHashMap { map, entry: None };
+        let boxed = RBox::new(boxed);
         unsafe {
-            let map = HashMap::<MapKey<K>, V, S>::with_hasher(hash_builder);
-            let boxed = BoxedHashMap { map, entry: None };
-            let boxed = RBox::new(boxed);
             mem::transmute::<RBox<_>, RBox<ErasedMap<K, V, S>>>(boxed)
         }
     }

--- a/abi_stable/src/std_types/string.rs
+++ b/abi_stable/src/std_types/string.rs
@@ -499,8 +499,8 @@ impl RString {
 
         let next = idx + ch.len_utf8();
         let len = self.len();
+        let ptr = self.inner.as_mut_ptr();
         unsafe {
-            let ptr = self.inner.as_mut_ptr();
             ptr::copy(ptr.add(next), ptr.add(idx), len - next);
             self.inner.set_len(len - (next - idx));
         }

--- a/abi_stable/src/std_types/utypeid.rs
+++ b/abi_stable/src/std_types/utypeid.rs
@@ -146,9 +146,9 @@ impl Hasher for TypeIdHasher {
     fn write(&mut self, bytes: &[u8]) {
         let _: [u8; MAX_TYPE_ID_SIZE - mem::size_of::<TypeId>()];
         if bytes.len() == mem::size_of::<TypeId>() {
+            let into = (&mut self.value) as *mut _ as *mut TypeIdArray;
+            let from = bytes.as_ptr() as *const TypeIdArray;
             unsafe {
-                let into = (&mut self.value) as *mut _ as *mut TypeIdArray;
-                let from = bytes.as_ptr() as *const TypeIdArray;
                 *into = *from;
             }
             self.written = mem::size_of::<TypeId>();

--- a/abi_stable/src/type_layout.rs
+++ b/abi_stable/src/type_layout.rs
@@ -330,13 +330,13 @@ impl TypeLayout {
     /// but are checked as part of the type
     #[inline]
     pub fn phantom_fields(&self) -> TLFields {
-        unsafe {
-            let slice = std::slice::from_raw_parts(
+        
+            let slice = unsafe { std::slice::from_raw_parts(
                 self.mono.phantom_fields,
                 self.mono.phantom_fields_len as usize,
-            );
+            ) };
             TLFields::from_fields(slice, self.shared_vars)
-        }
+        
     }
 
     /// Gets the generic parameters of the type.


### PR DESCRIPTION
In these function you use the unsafe keyword for almost the entrie function body. However, I found that only 5 functions are real unsafe operations (see the list below). 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 
**Real unsafe operation list:**
1. the sabi_erased_ref()/sabi_erased_mut()/clone_ptr()/default_ptr()/from_raw() function(these are unsafe functions)

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 
@rodrimati1992