### PR TITLE
added abi stable equivalents of closure traits

### DIFF
--- a/abi_stable/src/closures.rs
+++ b/abi_stable/src/closures.rs
@@ -1,0 +1,43 @@
+pub use rfn::*;
+
+mod rfn {
+    use crate::StableAbi;
+
+    #[crate::sabi_trait]
+    pub trait RFn<'a, In, Out> {
+        fn call(&self, input: In) -> Out;
+    }
+    impl<'a, In: StableAbi, Out: StableAbi, F: Fn(In) -> Out> RFn<'a, In, Out> for F {
+        fn call(&self, input: In) -> Out {
+            (self)(input)
+        }
+    }
+}
+
+mod rfnmut {
+    use crate::StableAbi;
+
+    #[crate::sabi_trait]
+    pub trait RFnMut<'a, In, Out> {
+        fn call_mut(&mut self, input: In) -> Out;
+    }
+    impl<'a, In: StableAbi, Out: StableAbi, F: FnMut(In) -> Out> RFnMut<'a, In, Out> for F {
+        fn call_mut(&mut self, input: In) -> Out {
+            (self)(input)
+        }
+    }
+}
+
+mod rfnonce {
+    use crate::StableAbi;
+
+    #[crate::sabi_trait]
+    pub trait RFnOnce<'a, In, Out> {
+        fn call_once(self, input: In) -> Out;
+    }
+    impl<'a, In: StableAbi, Out: StableAbi, F: FnOnce(In) -> Out> RFnOnce<'a, In, Out> for F {
+        fn call_once(self, input: In) -> Out {
+            (self)(input)
+        }
+    }
+}

--- a/abi_stable/src/lib.rs
+++ b/abi_stable/src/lib.rs
@@ -275,6 +275,7 @@ pub mod erased_types;
 pub mod external_types;
 #[macro_use]
 pub mod library;
+pub mod closures;
 pub mod inline_storage;
 pub mod marker_type;
 mod multikey_map;


### PR DESCRIPTION
Hiya,

Here's an proposal for some abi-stable equivalents of the Fn traits, to allow passing closures over the FFI boundary easily.

I'm planning on proposing something similar for `std::future::Future` soon (working on the `Waker` at the moment).

Let me know if you'd like to see some changes. Note that I only handled the single argument case, under the judgement call that if you want to pass multiple parameters to a closure over FFI, you might want to make sure the layout of the passed value suits you.