### PR TITLE
Fixed warnings since 1.64.0 (which will be errors in the future) in generated code.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,13 @@ Minor changes may be ommited, as well as improvements to documentation.
 
 # 0.10
 
+### Unreleased
+
+Fixed warnings since 1.64.0 (which will be errors in the future) in generated
+code for `sabi_trait`.
+
+Fixed warnings about unused values.
+
 ### 0.10.4
 
 Fixed compatibility with the nightly compiler.

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@ Minor changes may be ommited, as well as improvements to documentation.
 
 # 0.10
 
-### Unreleased
+### 0.10.5
 
 Fixed warnings since 1.64.0 (which will be errors in the future) in generated
 code for `sabi_trait`.

--- a/abi_stable/Cargo.toml
+++ b/abi_stable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abi_stable"
-version = "0.10.4"
+version = "0.10.5"
 authors = ["rodrimati1992 <rodrimatt1985@gmail.com>"]
 edition="2018"
 license = "MIT/Apache-2.0"

--- a/abi_stable/Cargo.toml
+++ b/abi_stable/Cargo.toml
@@ -69,6 +69,11 @@ crossbeam-channel = { version = "0.5.1", optional = true }
 serde_json = { version = "1.0.66", features = ["raw_value"], optional = true }
 paste = "1.0"
 
+# TODO: remove this dependency in abi_stable version 0.11, 
+# since that bumps the MSRV
+[dependencies.once_cell]
+version = ">=1.0.0, <1.10.0"
+
 [dependencies.core_extensions]
 default_features=false
 features=[
@@ -86,7 +91,7 @@ bincode = "1.3.3"
 crossbeam-utils = "0.8.5"
 serde_json = { version = "1.0.66", features = ["raw_value"] }
 rand = "0.8.4"
-hashbrown = "0.11.2"
+hashbrown = "0.11.0"
 fnv = "1.0.7"
 
 

--- a/abi_stable/src/marker_type.rs
+++ b/abi_stable/src/marker_type.rs
@@ -204,7 +204,10 @@ unsafe impl PrefixStableAbi for ErasedPrefix {
 /// [`StableAbi`]: ../trait.StableAbi.html
 ///
 pub struct UnsafeIgnoredType<T: ?Sized> {
-    _inner: PhantomData<T>,
+    /// This field must be public to promise (for semver) that a repr change would be a breaking
+    /// change (see https://github.com/rust-lang/rust/issues/78586), which is important as this is
+    /// used as a zero-sized type in `repr(transparent)` structs.
+    pub _inner: PhantomData<T>,
 }
 
 impl<T: ?Sized> UnsafeIgnoredType<T> {

--- a/abi_stable/src/sabi_types/rsmallbox.rs
+++ b/abi_stable/src/sabi_types/rsmallbox.rs
@@ -526,7 +526,7 @@ unsafe extern "C" fn destroy<T>(ptr: *mut T, drop_referent: CallReferentDrop, de
             ptr::drop_in_place(ptr);
         }
         if let Deallocate::Yes=dealloc{
-            Box::from_raw(ptr as *mut ManuallyDrop<T>);
+            drop(Box::from_raw(ptr as *mut ManuallyDrop<T>));
         }
     }
 }

--- a/abi_stable/src/std_types/boxed.rs
+++ b/abi_stable/src/std_types/boxed.rs
@@ -663,7 +663,7 @@ unsafe extern "C" fn destroy_box<T>(
             ptr::drop_in_place(ptr);
         }
         if let Deallocate::Yes = dealloc {
-            Box::from_raw(ptr as *mut ManuallyDrop<T>);
+            drop(Box::from_raw(ptr as *mut ManuallyDrop<T>));
         }
     }
 }


### PR DESCRIPTION
Changing the code generation of sabi_trait may have been more correct, but this is probably good enough.

Closes #94.