### PR TITLE
implement shallow_clone for `RObject`/`DynTrait`

### DIFF
--- a/abi_stable/src/erased_types/dyn_trait.rs
+++ b/abi_stable/src/erased_types/dyn_trait.rs
@@ -1575,6 +1575,19 @@ mod priv_ {
         }
     }
 
+    impl<'lt, I, EV: Clone> DynTrait<'lt, crate::std_types::RArc<()>, I, EV> {
+        /// Does a shallow clone of the object, just incrementing the reference counter
+        pub fn shallow_clone(&self) -> Self {
+            Self {
+                object: self.object.clone(),
+                vtable: self.vtable,
+                extra_value: self.extra_value.clone(),
+                _marker: self._marker,
+                _marker2: self._marker2,
+            }
+        }
+    }
+
     impl<'borr, P, I, EV> Drop for DynTrait<'borr, P, I, EV>
     where
         P: GetPointerKind,

--- a/abi_stable/src/sabi_trait/robject.rs
+++ b/abi_stable/src/sabi_trait/robject.rs
@@ -811,6 +811,17 @@ where
     }
 }
 
+impl<'lt, I, V> RObject<'lt, crate::std_types::RArc<()>, I, V> {
+    /// Does a shallow clone of the object, just incrementing the reference counter
+    pub fn shallow_clone(&self) -> Self {
+        Self {
+            vtable: self.vtable,
+            ptr: self.ptr.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
 impl<P, I, V> Drop for RObject<'_, P, I, V>
 where
     P: GetPointerKind,


### PR DESCRIPTION
Fixes #107 

Implement a `shallow_clone` function on `RObject`/`DynTrait` to allow cloning trait objects without cloning the underlying value.